### PR TITLE
Fixed bug in PostForm that duplicated tags when saving

### DIFF
--- a/src/components/forms/PostForm.js
+++ b/src/components/forms/PostForm.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { getAllCategories } from "../../services/categoryService";
+import { getAllCategories } from "../../services/categoriesService";
 import { createPost } from "../../services/postService";
 import "./forms.css";
 import { useNavigate } from "react-router-dom";

--- a/src/components/tags/PostTags.js
+++ b/src/components/tags/PostTags.js
@@ -1,6 +1,9 @@
 import { useEffect, useState } from "react";
-import { getAllTags } from "../../services/tagsService";
-import { createPostTags, getPostTagsByPostId } from "../../services/tagService";
+import {
+  getAllTags,
+  createPostTags,
+  getPostTagsByPostId,
+} from "../../services/tagService";
 import { useParams } from "react-router-dom";
 
 export const PostTags = ({ currentUser, post }) => {
@@ -38,23 +41,27 @@ export const PostTags = ({ currentUser, post }) => {
   const handleSave = () => {
     // Check if there are selected tags
     if (selectedTags.length > 0) {
-      const newTags = [];
+      // Filter out the selected tags that are already existing post tags
+      const newTags = selectedTags.filter((st) => {
+        return !postTags.some((pt) => pt.tag_id === st.id);
+      });
 
-      selectedTags.forEach((st) => {
-        const postTagObj = {
+      // Only create new post tags if there are selected tags that are not already existing
+      if (newTags.length > 0) {
+        const postTagsToCreate = newTags.map((st) => ({
           post_id: postId,
           tag_id: st.id,
-        };
-        newTags.push(postTagObj);
-      });
+        }));
 
-      // Only create tags if there are selected tags
-      createPostTags(newTags).then(() => {
-        getPostTagsByPostId(postId).then((res) => {
-          setPostTags(res);
+        createPostTags(postTagsToCreate).then(() => {
+          // After creating new post tags, fetch updated post tags
+          getPostTagsByPostId(postId).then((res) => {
+            setPostTags(res);
+          });
         });
-      });
+      }
     }
+
     setShowTagManagement(!showTagManagement);
   };
 

--- a/src/services/categoryService.js
+++ b/src/services/categoryService.js
@@ -1,3 +1,0 @@
-export const getAllCategories = () => {
-  return fetch(`http://localhost:9999/categories`).then((res) => res.json());
-};

--- a/src/services/tagsService.js
+++ b/src/services/tagsService.js
@@ -1,3 +1,0 @@
-export const getAllTags = () => {
-  return fetch(`http://localhost:9999/tags`).then((res) => res.json());
-};


### PR DESCRIPTION
This pull request addresses the issue of duplicating existing post tags when saving new tags in the PostTags component. The problem occurred when selecting new tags to add to a post and saving them, resulting in the existing tags being duplicated alongside the new ones. This PR references ticket #39 

Changes Made:
1. Modified the handleSave function in the PostTags component to filter out existing post tags from the selected tags before creating new ones.
2. Updated the logic to check if the selected tags include any existing post tags by comparing their IDs.
3. Only create new post tags for the selected tags that are not already existing, preventing duplication.
4. Added comments for clarity and documentation.

To test:
1. `git fetch --all` 
2. Switch to this branch `stacy/tags/add_tags_to_post/client`
3. If not logged in, login as a user from your database.
4. Click on `My Posts` in the nav bar
5. Click on one of the titles to navigate to the post details view.
6. Click `Manage Tags`
7. Select the tags you want
8. Click `Save` to save the selection and create the PostTag in the database
9. Verify that only the new selection was added and the previous ones where not duplicated.