### PR TITLE
Delete a comment from post

### DIFF
--- a/src/components/comments/ViewComments.js
+++ b/src/components/comments/ViewComments.js
@@ -1,10 +1,13 @@
 import { useEffect, useState } from "react";
-import { getCommentByPostId } from "../../services/commentService";
+import {
+  deleteComment,
+  getCommentByPostId,
+} from "../../services/commentService";
 import { Link, useParams } from "react-router-dom";
 import { getPostByPostId } from "../../services/postService";
 import "./Comments.css";
 
-export const ViewComments = () => {
+export const ViewComments = ({ currentUser }) => {
   const [postComment, setPostComment] = useState([]);
   const [singlePost, setSinglePost] = useState({});
   const { postId } = useParams();
@@ -20,6 +23,21 @@ export const ViewComments = () => {
       setPostComment(data);
     });
   }, [postId]);
+
+  const handleDelete = (comment) => {
+    // Display a confirmation before deleting the post
+    const isConfirmed = window.confirm(
+      "Are you sure you want to delete this post?"
+    );
+
+    if (isConfirmed) {
+      deleteComment(comment.id).then(() => {
+        getCommentByPostId(postId).then((res) => {
+          setPostComment(res);
+        });
+      });
+    }
+  };
 
   return (
     <div className="comments-container comment-block">
@@ -38,6 +56,12 @@ export const ViewComments = () => {
             <div>{comment.content}</div>
             <div>- {comment.author?.username}</div>
             <div>{comment.creation_datetime}</div>
+            {/*the button below will only show on comments the current user made */}
+            {currentUser.token === comment.author_id && (
+              <button onClick={() => handleDelete(comment)}>
+                <i className="fa-solid fa-trash-can"></i>
+              </button>
+            )}
           </div>
         );
       })}

--- a/src/components/views/ApplicationViews.js
+++ b/src/components/views/ApplicationViews.js
@@ -42,14 +42,14 @@ export const ApplicationViews = () => {
             path=":postId"
             element={<PostDetails currentUser={currentUser} />}
           />
-          <Route path=":postId/comments" element={<ViewComments />} />
-        </Route>
-        <Route path="myPosts">
-          <Route index element={<MyPosts currentUser={currentUser} />} />
           <Route
             path=":postId/add_a_comment"
             element={<CommentForm currentUser={currentUser} />}
           />
+          <Route path=":postId/comments" element={<ViewComments currentUser={currentUser}/>} />
+        </Route>
+        <Route path="myPosts">
+          <Route index element={<MyPosts currentUser={currentUser} />} />
         </Route>
         <Route
           path="newPost"

--- a/src/services/commentService.js
+++ b/src/services/commentService.js
@@ -22,3 +22,9 @@ export const createComment = (comment) => {
     body: JSON.stringify(comment),
   })
 }
+
+export const deleteComment = (commentId) => {
+  return fetch(`http://localhost:9999/comments/${commentId}`, {
+    method: "DELETE",
+  })
+}


### PR DESCRIPTION
I added DELETE functionality to the comments. Only the current user should see the option to delete their own comments otherwise there is no button shown. This completes ticket #27. 

To test:

1. `git fetch` 
2. Switch to this branch `stacy/comments/delete_comment/client`
3. Make sure the api is running.
4. If not logged in, login as a user from your database.
5. Navigate to the post details view of a post with comments
6. Click `view comments` to go to the comments list page
7. If the current user wrote one of the comments, a delete button should display otherwise there will be no button on the comment.
8. If the post does not have a comment by the current user, then you can go back to the post details and create a new comment.
9. Back in the comments list view click on the delete button/trash icon to delete comment.
10. A confirmation prompt should appear clicking `cancel` should not change anything and clicking `ok` should delete the comment from the database/comment list.